### PR TITLE
Correctly read symbols that start with numbers.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -32,6 +32,8 @@ function run() {
 run integer 1 1
 run integer -1 -1
 run symbol a "'a"
+run symbol 213a "'213a"
+run symbol -213a "'-213a"
 run quote a "(quote a)"
 run quote 63 "'63"
 run quote '(+ 1 2)' "'(+ 1 2)"


### PR DESCRIPTION
I took a stab at fixing #9 as a learning exercise. The changes will make values like '1a' or '-1a' be interpreted as a single symbol where before they were interpreted as a number followed by a symbol.

I added a couple test cases and everything seems to pass.. feedback is welcome if you have any!